### PR TITLE
Fix issue where script exit too early

### DIFF
--- a/test/run_tests.js
+++ b/test/run_tests.js
@@ -103,13 +103,14 @@ async function main() {
   playwrightChild.on("exit", (code) => {
     console.log(`child process exited with code ${code}`);
     //kill(serverChild.pid, "SIGTERM");
-    killAllTestServerProcess();
-    exit(code);
+    killAllTestServerProcess().then(() =>
+      exit(code)
+    );
   });
 }
 
 // On Ubuntu 22.04, testServer.js spawns two processes
-// Thus we go through and kill and all testServer processs include rouge one
+// Thus we go through and kill and all testServer process include rouge one
 async function killAllTestServerProcess() {
   const ps = await new Promise((res) => {
     exec("pgrep -f 'testServer.js'", (error, stdout, stderr) => {


### PR DESCRIPTION
Simple mistake of forgetting `killAllTestServerProcess()` is a Promise. So what would happen is that `exit()` would be called before `killAllTestServerProcess()` can finish. This would leave testServer.js instances running.

No version changes needed.