### PR TITLE
[FEATURE] Add compatibility with OnEditorEvent

### DIFF
--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -1,3 +1,5 @@
+declare const window: {OnEditorEvent? : (arg0: string, arg1: string) => void}
+
 import {AsyncMethodReturns, connectToChild} from "penpal";
 import {Result} from "./types";
 
@@ -260,14 +262,19 @@ export class PublisherInterface {
    * publisherInterface.addListener("FrameMoved", (targetId)=>{console.log(targetId)}));
    * ```
    * @param eventName - A case-sensitive string representing the editor event type to listen for.
-   * @param callbackFunction - A function that executes when the event is triggered.
+   * @param callbackFunction - A function that executes when the event is triggered. If callback is null, the listener will instead call window.OnEditorEvent
    */
   public async addListener(
     eventName: string,
-    callbackFunction: (targetId: string) => void
+    callbackFunction?: (targetId: string) => void
   ): Promise<void> {
-    !this.chiliEventListenerCallbacks.has(eventName) &&
-    this.chiliEventListenerCallbacks.set(eventName, callbackFunction);
+
+    console.log(this);
+
+    this.chiliEventListenerCallbacks.set(eventName, callbackFunction == null ? (targetId) => {
+      if (window.OnEditorEvent != null) window.OnEditorEvent(eventName, targetId)
+    } : callbackFunction)
+    
     const response = await this.child.addListener(eventName);
     if (response.isError) {
       throw new Error(response.error)

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -303,9 +303,7 @@ export class PublisherInterface {
     eventName: string,
     callbackFunction?: (targetId: string) => void
   ): Promise<void> {
-
-    console.log(this);
-
+    
     this.chiliEventListenerCallbacks.set(eventName, callbackFunction == null ? (targetId) => {
       if (window.OnEditorEvent != null) window.OnEditorEvent(eventName, targetId)
     } : callbackFunction)

--- a/test/tests/OnEditorEvent.js
+++ b/test/tests/OnEditorEvent.js
@@ -1,0 +1,15 @@
+export default async function (createInterface) {
+
+  const publisherInterface = await createInterface();
+
+  await publisherInterface.addListener("DocumentFullyRendered");
+  return new Promise((resolve) => {
+    window.OnEditorEvent = (eventName, targetId) => {
+      if (eventName == "DocumentFullyRendered" && targetId != null) resolve(true);
+    };
+
+    setTimeout(() => {
+      resolve(false);
+    }, 8000);
+  });
+}

--- a/test/tests/registerEventsOnBuild.js
+++ b/test/tests/registerEventsOnBuild.js
@@ -1,0 +1,21 @@
+export default async function (createInterface) {
+  
+  let loaded = false;
+  let targetIdLoaded = null;
+
+  const publisherInterface = await createInterface({events:["DocumentFullyRendered", {name:"DocumentFullyLoaded", func:(id) => {
+    loaded = true
+    targetIdLoaded = id
+  }}]});
+  
+  await publisherInterface.addListener("DocumentFullyRendered");
+  return new Promise((resolve) => {
+    window.OnEditorEvent = (eventName, targetId) => {
+      if (eventName == "DocumentFullyRendered" && targetId == targetIdLoaded && loaded) resolve(true);
+    };
+
+    setTimeout(() => {
+      resolve(false);
+    }, 8000);
+  });
+}


### PR DESCRIPTION
When you use addListener with a null callback, the event will now trigger `window.OnEditorEvent` (if OnEditorEvent is not null) passing in the event name and target ID.

This is to make things backwards compatible with the previous workflow of `using window.OnEditorEvent()` to handle events.