### PR TITLE
[FEATURE] Add alias for editorObject

### DIFF
--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -137,6 +137,41 @@ export class PublisherInterface {
     return eventName;
   }
 
+  private _editorObject:EditorObjectAlias|null = null
+  /**
+   * Returns an alias for editorObject with similarly named functions. This is to help with backwards compatibility, but these functions still return a Promise.
+   */
+  get editorObject() {
+    if (this._editorObject == null) {
+      this._editorObject = {
+          Alert: this.alert.bind(this),
+          GetDirtyState: this.getDirtyState.bind(this),
+          NextPage: this.nextPage.bind(this),
+          PreviousPage: this.previousPage.bind(this),
+          SetSelectedPage: this.setSelectedPage.bind(this),
+          GetSelectedPage: this.getSelectedPage.bind(this),
+          GetSelectedPageName: this.getSelectedPageName.bind(this),
+          GetNumPages: this.getNumPages.bind(this),
+          RemoveListener:this.removeListener.bind(this),
+          AddListener: this.addListener.bind(this),
+          GetObject: this.getObject.bind(this),
+          SetProperty: this.setProperty.bind(this),
+          ExecuteFunction: this.executeFunction.bind(this),
+          GetPageSnapshot: this.getPageSnapshot.bind(this),
+          GetFrameSnapshot: this.getFrameSnapshot.bind(this),
+          GetFrameSubjectArea: this.getFrameSubjectArea.bind(this),
+          SetFrameSubjectArea: this.setFrameSubjectArea.bind(this),
+          ClearFrameSubjectArea: this.clearFrameSubjectArea.bind(this),
+          GetAssetSubjectInfo: this.getAssetSubjectInfo.bind(this),
+          SetAssetSubjectInfo: this.setAssetSubjectInfo.bind(this),
+          ClearAssetSubjectInfo: this.clearAssetSubjectInfo.bind(this),
+          SetVariableIsLocked: this.setVariableIsLocked.bind(this),
+        }
+    }
+
+    return this._editorObject;
+  }
+
   /**
    * Displays a modal box within the editor UI containing a title with a message.
    *
@@ -549,4 +584,31 @@ export class PublisherInterface {
   }
 }
 
+/**
+   *  An alias for the editorObject
+*/
+export type EditorObjectAlias = {
+  Alert: PublisherInterface["alert"],
+  GetDirtyState: PublisherInterface["getDirtyState"],
+  NextPage: PublisherInterface["nextPage"],
+  PreviousPage: PublisherInterface["previousPage"],
+  SetSelectedPage: PublisherInterface["setSelectedPage"],
+  GetSelectedPage: PublisherInterface["getSelectedPage"],
+  GetSelectedPageName: PublisherInterface["getSelectedPageName"],
+  GetNumPages: PublisherInterface["getNumPages"],
+  RemoveListener:PublisherInterface["removeListener"],
+  AddListener: PublisherInterface["addListener"],
+  GetObject: PublisherInterface["getObject"],
+  SetProperty: PublisherInterface["setProperty"],
+  ExecuteFunction: PublisherInterface["executeFunction"],
+  GetPageSnapshot: PublisherInterface["getPageSnapshot"],
+  GetFrameSnapshot: PublisherInterface["getFrameSnapshot"],
+  GetFrameSubjectArea: PublisherInterface["getFrameSubjectArea"],
+  SetFrameSubjectArea: PublisherInterface["setFrameSubjectArea"],
+  ClearFrameSubjectArea: PublisherInterface["clearFrameSubjectArea"],
+  GetAssetSubjectInfo: PublisherInterface["getAssetSubjectInfo"],
+  SetAssetSubjectInfo: PublisherInterface["setAssetSubjectInfo"],
+  ClearAssetSubjectInfo: PublisherInterface["clearAssetSubjectInfo"],
+  SetVariableIsLocked: PublisherInterface["setVariableIsLocked"]
+}
 

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -137,13 +137,13 @@ export class PublisherInterface {
     return eventName;
   }
 
-  private _editorObject:EditorObjectAlias|null = null
+  #editorObject:EditorObjectAlias|null = null
   /**
    * Returns an alias for editorObject with similarly named functions. This is to help with backwards compatibility, but these functions still return a Promise.
    */
   get editorObject() {
-    if (this._editorObject == null) {
-      this._editorObject = {
+    if (this.#editorObject == null) {
+      this.#editorObject = {
           Alert: this.alert.bind(this),
           GetDirtyState: this.getDirtyState.bind(this),
           NextPage: this.nextPage.bind(this),
@@ -169,7 +169,7 @@ export class PublisherInterface {
         }
     }
 
-    return this._editorObject;
+    return this.#editorObject;
   }
 
   /**

--- a/test/tests/AddListener.js
+++ b/test/tests/AddListener.js
@@ -1,0 +1,14 @@
+export default async function (createInterface) {
+
+  const publisherInterface = await createInterface();
+
+  return new Promise((resolve) => {
+    publisherInterface.editorObject.AddListener("DocumentFullyRendered", () => {
+      resolve(true);
+    });
+
+    setTimeout(() => {
+      resolve(false);
+    }, 8000);
+  });
+}

--- a/test/tests/ExecuteFunction.js
+++ b/test/tests/ExecuteFunction.js
@@ -1,0 +1,30 @@
+export default async function (createInterface) {
+
+  const publisherInterface = await createInterface();
+
+  await new Promise((resolve) =>
+    publisherInterface.addListener("DocumentFullyLoaded", resolve)
+  );
+
+  const count = await publisherInterface.editorObject.GetObject("document.variables.count");
+
+  const newVariable = await publisherInterface.editorObject.ExecuteFunction(
+    "document.variables",
+    "Add"
+  );
+  await publisherInterface.editorObject.SetProperty(
+    "document.variables[" + newVariable.id + "]",
+    "value",
+    "stuff"
+  );
+
+  const newCount = await publisherInterface.getObject(
+    "document.variables.count"
+  );
+
+  if (newCount > count) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Many integrations will need to move over to Publisher Interface and all there code will use PascalCase function calls. This provides an easy alias to make it easier to those code bases to upgrade to Publisher Interface.

This does not solve the fact that these functions still return a Promise.