### PR TITLE
Wiki fix .then() syntax build function

### DIFF
--- a/src/Differences With editorObject.md
+++ b/src/Differences With editorObject.md
@@ -13,12 +13,12 @@ A small, but important difference is that the methods from the `PublisherInterfa
 
 ✏️ The editorObject way:
 ```javascript
-editorObject.ExecuteFunction("document", "save");
+editorObject.ExecuteFunction("document", "Save");
 ```
 
 💻 The publisher way:
 ```javascript
-await publisher.executeFunction("document", "save");
+await publisher.executeFunction("document", "Save");
 ```
 
 <br/>

--- a/src/Differences With editorObject.md
+++ b/src/Differences With editorObject.md
@@ -25,7 +25,7 @@ await publisher.executeFunction("document", "Save");
 
 There is a convenience getter on the `PublisherInterface` class named [editorObject](PublisherInterface.md#editorobject) which acts as an alias that can help current implementations switch to Publisher Interface.
 
-See [Moving to Publisher Connector](Moving-to-Publisher-Connector.md#dealing-with-publisherinterface-api-name-changes) for more details.
+See [Moving to Publisher Interface](Moving-to-Publisher-Connector.md#dealing-with-publisherinterface-api-name-changes) for more details.
 
 ## Promise as a Return
 While the `editorObject` methods return by holding up the main thread, the `PublisherInterface` methods use `postMessage()` under the hood. This means that the message must be serialized, sent, and deserialized across from one window to another. It is a message system, and thus things happen asynchronously.

--- a/src/Home.md
+++ b/src/Home.md
@@ -76,8 +76,9 @@ Then in your JavaScript code, get the iframe which is loading the Publisher edit
 
 ```javascript
 const iframe = document.getElementById("editor-iframe");
-const publisher = PublisherInterface.build(iframe).then(
-    PublisherInterface => PublisherInterface.alert("Hi!")
+
+PublisherInterface.build(iframe).then(
+    publisher => publisher.alert("Hi!")
 );
 ```
 

--- a/src/Moving to Publisher Interface.md
+++ b/src/Moving to Publisher Interface.md
@@ -231,7 +231,7 @@ The best suggestion is to rework your logic around the waiting for the `build()`
 // This must be done before iframe onload event
 function beforeIFrameLoaded() {
   iframe = document.getElementById("chili-iframe");
-  PublisherConnector.build(iframe).then(myCallback);
+  PublisherInterface.build(iframe).then(myCallback);
 }
 
 function myCallback(publisher)
@@ -246,7 +246,7 @@ Again, it might make more sense to use async/await
 // This must be done before iframe onload event
 function beforeIFrameLoaded() {
   iframe = document.getElementById("chili-iframe");
-  const publisher = await PublisherConnector.build(iframe);
+  const publisher = await PublisherInterfacer.build(iframe);
   myCallback(publisher);
 }
 

--- a/src/Moving to Publisher Interface.md
+++ b/src/Moving to Publisher Interface.md
@@ -246,7 +246,7 @@ Again, it might make more sense to use async/await
 // This must be done before iframe onload event
 function beforeIFrameLoaded() {
   iframe = document.getElementById("chili-iframe");
-  const publisher = await PublisherInterfacer.build(iframe);
+  const publisher = await PublisherInterface.build(iframe);
   myCallback(publisher);
 }
 

--- a/src/Moving to Publisher Interface.md
+++ b/src/Moving to Publisher Interface.md
@@ -145,12 +145,12 @@ As you read in [Differences With editorObject](https://github.com/chili-publish/
 
 ✏️ The editorObject way:
 ```javascript
-editorObject.ExecuteFunction("document", "save");
+editorObject.ExecuteFunction("document", "Save");
 ```
 
 💻 The publisher way:
 ```javascript
-await publisher.executeFunction("document", "save");
+await publisher.executeFunction("document", "Save");
 ```
 
 <br/>
@@ -159,14 +159,14 @@ There is a convenience getter on the `PublisherInterface` class named [editorObj
 
 Using the getter we could rewrite our publisher example as: 
 ```javascript
-await publisher.editorObject.ExecuteFunction("document", "save");
+await publisher.editorObject.ExecuteFunction("document", "Save");
 ```
 
 If your integration has lots of method calls to the `editorObject` then this getter can be used to save some modification time. You can even capture this in a variable called *editorObject* or *editor* to then pass onto your code.
 
 ```javascript
 const editorObject = publisher.editorObject
-await editorObject.ExecuteFunction("document", "save");
+await editorObject.ExecuteFunction("document", "Save");
 ```
 
 There is one danger in using this convenience getter. That danger is you forget about the `async` keyword. This convenience getter does not magically make Promises into original values. The way Publisher Interface uses a message system means that getting rid of callbacks or async/await is not possible.


### PR DESCRIPTION
Made changes to the .then() example on the Wiki home page. 

I chose to bind to `publisher` just because most of the other examples throughout the wiki are now using publisher.fn() syntax for examples. 