### PR TITLE
Fix publisher build .then() example

### DIFF
--- a/src/Home.md
+++ b/src/Home.md
@@ -76,8 +76,8 @@ Then in your JavaScript code, get the iframe which is loading the Publisher edit
 
 ```javascript
 const iframe = document.getElementById("editor-iframe");
-const publisher = PublisherInterface.build(iframe).then(
-    PublisherInterface => PublisherInterface.alert("Hi!")
+PublisherInterface.build(iframe).then(
+    publisher => publisher.alert("Hi!")
 );
 ```
 


### PR DESCRIPTION
I chose to bind to `publisher` because most other examples throughout the wiki utilize the variable name `publisher` to refer to the resolved PublisherInterface promise