### PR TITLE
Run customer JS Functions

### DIFF
--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -7,7 +7,7 @@ declare const window: Window &
     OnEditorEvent: any;
     publisher: any;
     registeredFunctions: Map<string, (publisher:any) => void>;
-    registeredEventFunctions: Map<string, (publisher:any) => void>
+    registeredEventFunctions: Map<string, (publisher:any, id:string) => void>
   };
 
 window.registeredFunctions = new Map();
@@ -88,7 +88,7 @@ const setUpConnection = () => {
 
     const eventFunc = window.registeredEventFunctions.get(eventName);
 
-    if (eventFunc != null) eventFunc(window.publisher);
+    if (eventFunc != null) eventFunc(window.publisher, id);
 
     connection.promise.then((parent) => {
       parent.handleEvents(eventName, id);
@@ -98,7 +98,7 @@ const setUpConnection = () => {
 
 const registerFunction = (name:string, body:string) => {
   try {
-    window.registeredFunctions.set(name, new Function("publisher", body) as any);
+    window.registeredFunctions.set(name, new Function("publisher", "id", body) as any);
     return Ok(undefined);
   }
   catch(e) {

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -5,6 +5,7 @@ declare const window: Window &
   typeof globalThis & {
     editorObject: any;
     OnEditorEvent: any;
+    registeredFunctions: Map<string, (editor:any) => void>
   };
 
 interface InternalWrapper {
@@ -24,6 +25,8 @@ const setUpConnection = () => {
   connection = connectToParent<InternalWrapper>({
     // Methods child is exposing to parent.
     methods: {
+      registerFunction,
+      runRegisteredFunction,
       alert,
       getDirtyState,
       nextPage,
@@ -55,6 +58,17 @@ const setUpConnection = () => {
     });
   };
 };
+
+window.registeredFunctions = new Map();
+
+const registerFunction = (name:string, body:string) => {
+  window.registeredFunctions.set(name, new Function(body, window.editorObject) as any);
+}
+
+const runRegisteredFunction = (name:string) => {
+  const func = window.registeredFunctions.get(name);
+  if (func != null) func(window.editorObject);
+}
 
 const alert = (
   message: string,

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -23,79 +23,6 @@ const editorCheck = setInterval(() => {
   }
 }, 500);
 
-let connection: Connection<InternalWrapper>;
-const setUpConnection = () => {
-  clearInterval(editorCheck);
-
-  connection = connectToParent<InternalWrapper>({
-    // Methods child is exposing to parent.
-    methods: {
-      registerFunction,
-      registerFunctionOnEvent,
-      runRegisteredFunction,
-      alert,
-      getDirtyState,
-      nextPage,
-      previousPage,
-      setSelectedPage,
-      getSelectedPage,
-      getSelectedPageName,
-      getNumPages,
-      removeListener,
-      addListener,
-      setProperty,
-      getObject,
-      executeFunction,
-      getPageSnapshot,
-      getFrameSnapshot,
-      getFrameSubjectArea,
-      setFrameSubjectArea,
-      clearFrameSubjectArea,
-      getAssetSubjectInfo,
-      setAssetSubjectInfo,
-      clearAssetSubjectInfo,
-      setVariableIsLocked,
-    },
-  });
-
-  window.publisher = {
-    alert: window.editorObject.Alert,
-    getDirtyState: window.editorObject.GetDirtyState,
-    nextPage: window.editorObject.NextPage,
-    previousPage: window.editorObject.PreviousPage,
-    setSelectedPage: window.editorObject.SetSelectedPage,
-    getSelectedPage: window.editorObject.GetSelectedPage,
-    getSelectedPageName: window.editorObject.GetSelectedPageName,
-    getNumPages: window.editorObject.GetNumPages,
-    removeListener: window.editorObject.RemoveListener,
-    addListener: window.editorObject.AddListener,
-    getObject: window.editorObject.GetObject,
-    setProperty: window.editorObject.SetProperty,
-    executeFunction: window.editorObject.ExecuteFunction,
-    getPageSnapshot: window.editorObject.GetPageSnapshot,
-    getFrameSnapshot: window.editorObject.GetFrameSnapshot,
-    getFrameSubjectArea: window.editorObject.GetFrameSubjectArea,
-    setFrameSubjectArea: window.editorObject.SetFrameSubjectArea,
-    clearFrameSubjectArea: window.editorObject.ClearFrameSubjectArea,
-    getAssetSubjectInfo: window.editorObject.GetAssetSubjectInfo,
-    setAssetSubjectInfo: window.editorObject.SetAssetSubjectInfo,
-    clearAssetSubjectInfo: window.editorObject.ClearAssetSubjectInfo,
-    setVariableIsLocked: window.editorObject.SetVariableIsLocked,
-    editorObject: window.editorObject
-  }
-
-  window.OnEditorEvent = (eventName: string, id: string) => {
-
-    const eventFunc = window.registeredEventFunctions.get(eventName);
-
-    if (eventFunc != null) eventFunc(window.publisher, id);
-
-    connection.promise.then((parent) => {
-      parent.handleEvents(eventName, id);
-    });
-  };
-};
-
 const registerFunction = (name:string, body:string) => {
   try {
     window.registeredFunctions.set(name, new Function("publisher", "id", body) as any);
@@ -402,4 +329,103 @@ const setVariableIsLocked = (
   } catch (e) {
     return Err((e as Error).toString());
   }
+};
+
+const setUpConnection = () => {
+  clearInterval(editorCheck);
+
+  const connection: Connection<InternalWrapper> = connectToParent<InternalWrapper>({
+    // Methods child is exposing to parent.
+    methods: {
+      registerFunction,
+      registerFunctionOnEvent,
+      runRegisteredFunction,
+      alert,
+      getDirtyState,
+      nextPage,
+      previousPage,
+      setSelectedPage,
+      getSelectedPage,
+      getSelectedPageName,
+      getNumPages,
+      removeListener,
+      addListener,
+      setProperty,
+      getObject,
+      executeFunction,
+      getPageSnapshot,
+      getFrameSnapshot,
+      getFrameSubjectArea,
+      setFrameSubjectArea,
+      clearFrameSubjectArea,
+      getAssetSubjectInfo,
+      setAssetSubjectInfo,
+      clearAssetSubjectInfo,
+      setVariableIsLocked,
+    },
+  });
+
+  window.publisher = {
+    registerFunction: (name:string, body:string) => {
+      const res = registerFunction(name, body);
+      if (res.isError) {
+        throw new Error(res.error);
+      }
+      else {
+        return res.ok;
+      }
+    },
+    registerFunctionOnEvent: (eventName:string, body:string) => {
+      const res = registerFunctionOnEvent(eventName, body);
+      if (res.isError) {
+        throw new Error(res.error);
+      }
+      else {
+        return res.ok;
+      }
+    },
+    runRegisteredFunction: (name:string) => {
+      const res = runRegisteredFunction(name);
+      if (res.isError) {
+        throw new Error(res.error);
+      }
+      else {
+        return res.ok;
+      }
+    },
+    alert: window.editorObject.Alert,
+    getDirtyState: window.editorObject.GetDirtyState,
+    nextPage: window.editorObject.NextPage,
+    previousPage: window.editorObject.PreviousPage,
+    setSelectedPage: window.editorObject.SetSelectedPage,
+    getSelectedPage: window.editorObject.GetSelectedPage,
+    getSelectedPageName: window.editorObject.GetSelectedPageName,
+    getNumPages: window.editorObject.GetNumPages,
+    removeListener: window.editorObject.RemoveListener,
+    addListener: window.editorObject.AddListener,
+    getObject: window.editorObject.GetObject,
+    setProperty: window.editorObject.SetProperty,
+    executeFunction: window.editorObject.ExecuteFunction,
+    getPageSnapshot: window.editorObject.GetPageSnapshot,
+    getFrameSnapshot: window.editorObject.GetFrameSnapshot,
+    getFrameSubjectArea: window.editorObject.GetFrameSubjectArea,
+    setFrameSubjectArea: window.editorObject.SetFrameSubjectArea,
+    clearFrameSubjectArea: window.editorObject.ClearFrameSubjectArea,
+    getAssetSubjectInfo: window.editorObject.GetAssetSubjectInfo,
+    setAssetSubjectInfo: window.editorObject.SetAssetSubjectInfo,
+    clearAssetSubjectInfo: window.editorObject.ClearAssetSubjectInfo,
+    setVariableIsLocked: window.editorObject.SetVariableIsLocked,
+    editorObject: window.editorObject
+  }
+
+  window.OnEditorEvent = (eventName: string, id: string) => {
+
+    const eventFunc = window.registeredEventFunctions.get(eventName);
+
+    if (eventFunc != null) eventFunc(window.publisher, id);
+
+    connection.promise.then((parent) => {
+      parent.handleEvents(eventName, id);
+    });
+  };
 };

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -36,7 +36,7 @@ const registerFunction = (name:string, body:string) => {
 const registerFunctionOnEvent = (eventName:string, body:string) => {
   try {
     window.editorObject.AddListener(eventName);
-    window.registeredEventFunctions.set(eventName, new Function("publisher", body) as any);
+    window.registeredEventFunctions.set(eventName, new Function("publisher", "id", body) as any);
     return Ok(undefined);
   }
   catch(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chili-publish/publisher-interface",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": "chili-publish",
   "description": "PublisherInterface is a class object that allows you to interact with the CHILI Publisher editorObject via postMessage without the complexity of postMessage.",
   "repository": {

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -7,6 +7,8 @@ interface ChiliWrapper {
 
   registerFunction(name:string, body:string): Result<undefined>;
 
+  registerFunctionOnEvent(eventName:string, body:string): Result<undefined>;
+
   runRegisteredFunction(name: string): Result<string | number | boolean | object | null | undefined>;
 
   alert(
@@ -244,6 +246,21 @@ export class PublisherInterface {
       throw new Error(response.error)
     }
   }
+
+  /**
+   * Register a custom function on the iframe side. The function takes one parameter: the editorObject. This function has access to the window, so you can register events to OnEditorEvent. You can access other custom functions in your custom function using window.registeredFunctions, which is a Map. 
+   * 
+   * @param name - The name of the function to register.
+   * @param body - The body of the function.
+   */
+  public async registerFunctionOnEvent(eventName:string, body:string): Promise<void> {
+    this.createDebugLog("registerFunction()");
+    const response = await this.child.registerFunctionOnEvent(eventName, body);
+    if (response.isError) {
+      throw new Error(response.error)
+    }
+  }
+
 
   /**
    * Runs function that was registered originally by reisterFunction on the iframe side.

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -234,7 +234,7 @@ export class PublisherInterface {
   }
 
   /**
-   * Register a custom function on the iframe side. The function takes one parameter: the editorObject. This function has access to the window, so you can register events to OnEditorEvent. You can access other custom functions in your custom function using window.registeredFunctions, which is a Map. 
+   * Register a custom function on the iframe side. The function takes one parameter: publisher. This function has access to the window. You can access other custom functions registered using window.registeredFunctions, which is a Map. 
    * 
    * @param name - The name of the function to register.
    * @param body - The body of the function.
@@ -248,9 +248,9 @@ export class PublisherInterface {
   }
 
   /**
-   * Register a custom function on the iframe side. The function takes one parameter: the editorObject. This function has access to the window, so you can register events to OnEditorEvent. You can access other custom functions in your custom function using window.registeredFunctions, which is a Map. 
+   * Register a custom function on the iframe side that runs when an event is called. The function takes two parameters: publisher and id. This function has access to the window. You can access other custom functions registered using window.registeredFunctions, which is a Map.
    * 
-   * @param name - The name of the function to register.
+   * @param eventName - The name of the event to trigger the function.
    * @param body - The body of the function.
    */
   public async registerFunctionOnEvent(eventName:string, body:string): Promise<void> {

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -4,6 +4,11 @@ import {AsyncMethodReturns, connectToChild} from "penpal";
 import {Result} from "./types";
 
 interface ChiliWrapper {
+
+  registerFunction(name:string, body:string): Result<undefined>;
+
+  runRegisteredFunction(name: string): Result<string | number | boolean | object | null | undefined>;
+
   alert(
     message: string,
     title: string
@@ -224,6 +229,34 @@ export class PublisherInterface {
     }
 
     return this.#editorObject;
+  }
+
+  /**
+   * Register a custom function on the iframe side. The function takes one parameter: the editorObject. This function has access to the window, so you can register events to OnEditorEvent. You can access other custom functions in your custom function using window.registeredFunctions, which is a Map. 
+   * 
+   * @param name - The name of the function to register.
+   * @param body - The body of the function.
+   */
+  public async registerFunction(name:string, body:string): Promise<undefined> {
+    this.createDebugLog("registerFunction()");
+    const response = await this.child.registerFunction(name, body);
+    if (response.isError) {
+      throw new Error(response.error)
+    }
+  }
+
+  /**
+   * Runs function that was registered originally by reisterFunction on the iframe side.
+   * 
+   * @param name - The name of the functin to run.
+   */
+  public async runRegisteredFunction(name: string): Promise<string | number | boolean | object | null | undefined> {
+    this.createDebugLog("runReisteredFunction()");
+    const response = await this.child.runRegisteredFunction(name);
+    if (response.isError) {
+      throw new Error(response.error);
+    }
+    return response.ok;
   }
 
   /**

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -237,7 +237,7 @@ export class PublisherInterface {
    * @param name - The name of the function to register.
    * @param body - The body of the function.
    */
-  public async registerFunction(name:string, body:string): Promise<undefined> {
+  public async registerFunction(name:string, body:string): Promise<void> {
     this.createDebugLog("registerFunction()");
     const response = await this.child.registerFunction(name, body);
     if (response.isError) {


### PR DESCRIPTION
Custom JS functions allow users to get around the performance lag due to postMessage by registering a function and passing the function body as a string, and then call that function via postMessage to run on the iframe side.

This update also adds window.publisher to be able to use PublisherInterface on the iframe side.

Documentation needs to be updated, but we are going to push the update and then the documentation.