### PR TITLE
Feature fix/iframe improvements

### DIFF
--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -180,13 +180,13 @@ const setProperty = (
 const executeFunction = (
   chiliPath: string,
   functionName: string,
-  params: (string | number | boolean | null | undefined)[]
+  args: (string | number | boolean | null | undefined)[]
 ): Result<string | number | boolean | object | null | undefined> => {
   try {
     return Ok(window.editorObject.ExecuteFunction(
       chiliPath,
       functionName,
-      ...params
+      ...args
     ));
   } catch (e) {
     return Err((e as Error).toString());

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -6,7 +6,7 @@ declare const window: Window &
     editorObject: any;
     OnEditorEvent: any;
     publisher: any;
-    registeredFunctions: Map<string, (publisher:any, args:any[]) => void>;
+    registeredFunctions: Map<string, (publisher:any, ...args:any) => void>;
     registeredEventFunctions: Map<string, (publisher:any, id:string) => void>;
     listenerEventShimFunctions: Map<string, (id:string) => void>;
   };
@@ -50,7 +50,7 @@ const executeRegisteredFunction = (name:string, args:any[]) => {
   try {
     const func = window.registeredFunctions.get(name);
     if (func != null) {
-      return Promise.resolve(func(window.publisher, args)).then(res => Ok(res), err => Err((err as Error).toString()))
+      return Promise.resolve(func(window.publisher, ...args)).then(res => Ok(res), err => Err((err as Error).toString()))
     }
     return Promise.resolve(Err(`Function ${name} not found`));
   }
@@ -386,7 +386,7 @@ const setUpConnection = () => {
           return res.ok;
         }
       }),
-      execute: (name:string, args:any[]) => {
+      execute: (name:string, ...args:any[]) => {
         return executeRegisteredFunction(name, args).then(res => {
           if (res.isError) {
             throw new Error(res.error);

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -6,8 +6,8 @@ declare const window: Window &
     editorObject: any;
     OnEditorEvent: any;
     publisher: any;
-    registeredFunctions: Map<string, (publisher:any, ...args:any) => void>;
-    registeredEventFunctions: Map<string, (publisher:any, id:string) => void>;
+    registeredFunctions: Map<string, (...args:any) => void>;
+    registeredEventFunctions: Map<string, (id:string) => void>;
     listenerEventShimFunctions: Map<string, (id:string) => void>;
   };
 
@@ -27,7 +27,7 @@ const editorCheck = setInterval(() => {
 
 const registerFunction = (name:string, body:string) => {
   try {
-    window.registeredFunctions.set(name, new Function("publisher", "args", body) as any);
+    window.registeredFunctions.set(name, new Function("args", body) as any);
     return Ok(undefined);
   }
   catch(e) {
@@ -38,7 +38,7 @@ const registerFunction = (name:string, body:string) => {
 const registerFunctionOnEvent = (eventName:string, body:string) => {
   try {
     window.editorObject.AddListener(eventName);
-    window.registeredEventFunctions.set(eventName, new Function("publisher", "targetID", body) as any);
+    window.registeredEventFunctions.set(eventName, new Function("targetID", body) as any);
     return Ok(undefined);
   }
   catch(e) {
@@ -50,7 +50,7 @@ const executeRegisteredFunction = (name:string, args:any[]) => {
   try {
     const func = window.registeredFunctions.get(name);
     if (func != null) {
-      return Promise.resolve(func(window.publisher, ...args)).then(res => Ok(res), err => Err((err as Error).toString()))
+      return Promise.resolve(func(...args)).then(res => Ok(res), err => Err((err as Error).toString()))
     }
     return Promise.resolve(Err(`Function ${name} not found`));
   }
@@ -448,7 +448,7 @@ const setUpConnection = () => {
   window.OnEditorEvent = (eventName: string, id: string) => {
 
     const registeredFunc = window.registeredEventFunctions.get(eventName);
-    if (registeredFunc != null) registeredFunc(window.publisher, id);
+    if (registeredFunc != null) registeredFunc(id);
 
     const listenerFunc = window.listenerEventShimFunctions.get(eventName);
     if (listenerFunc != null) listenerFunc(id);

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -27,7 +27,7 @@ const editorCheck = setInterval(() => {
 
 const registerFunction = (name:string, body:string) => {
   try {
-    window.registeredFunctions.set(name, new Function("args", body) as any);
+    window.registeredFunctions.set(name, new Function(body) as any);
     return Ok(undefined);
   }
   catch(e) {

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -461,7 +461,9 @@ const setUpConnection = () => {
 
 function addListenerShim(eventName:string, callbackFunction?: (targetId: string) => void) {
   window.editorObject.AddListener(eventName);
-  window.listenerEventShimFunctions.set(eventName, callbackFunction ?? ((t) => {return}));
+  if (callbackFunction != null) {
+    window.listenerEventShimFunctions.set(eventName, callbackFunction);
+  }
 }
 
 function removeListenerShim(eventName:string) {

--- a/onServer/chiliInternalWrapper.ts
+++ b/onServer/chiliInternalWrapper.ts
@@ -460,12 +460,12 @@ const setUpConnection = () => {
 };
 
 function addListenerShim(eventName:string, callbackFunction?: (targetId: string) => void) {
-  window.editorObject.addListener(eventName);
+  window.editorObject.AddListener(eventName);
   window.listenerEventShimFunctions.set(eventName, callbackFunction ?? ((t) => {return}));
 }
 
 function removeListenerShim(eventName:string) {
-  window.editorObject.removeListener(eventName);
+  window.editorObject.RemoveListener(eventName);
   window.listenerEventShimFunctions.delete(eventName);
 }
 

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -154,9 +154,9 @@ export type CustomFunctionsInterface = {
    * Executes a function that was registered originally by registerFunction on the iframe window side and allows you to pass any number of args. It will return the result of the called function.
    * 
    * @param name - The name of the function to run.
-   * @param args - An array that will be passed to the function - items in array need survive JSON.stringify
+   * @param args - Arguments that will be passed to the function
    */
-    execute: (name: string, args:any[]) => Promise<any>
+    execute: (name: string, ...args:any) => Promise<any>
 }
 
 
@@ -179,7 +179,7 @@ const createCustomFunctionsInterface = function(chiliWrapper:AsyncMethodReturns<
       }
     },
   
-    execute: async function(name: string, args:any[] = []): Promise<any> {
+    execute: async function(name: string, ...args:any): Promise<any> {
       createDebugLog("executeRegisteredFunction()");
       const response = await chiliWrapper.executeRegisteredFunction(name, args);
       if (response.isError) {

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -51,7 +51,7 @@ interface ChiliWrapper {
   executeFunction(
     chiliPath: string,
     functionName: string,
-    params: (string | number | boolean | null | undefined)[]
+    args: (string | number | boolean | null | undefined)[]
   ):
     | Result<string | number | boolean | object | null | undefined>;
 
@@ -505,19 +505,19 @@ export class PublisherInterface {
    * ```
    * @param chiliPath - A case-sensitive string query path for selecting properties and objects in a CHILI document.
    * @param functionName - A case-sensitive string of the name of the function to execute.
-   * @param params - Parameters to be passed to function of functionName.
+   * @param args - Parameters to be passed to function of functionName.
    * @returns Returns the return of executed function.
    */
   public async executeFunction(
     chiliPath: string,
     functionName: string,
-    ...params: (string | number | boolean | null | undefined)[]
+    ...args: (string | number | boolean | null | undefined)[]
   ): Promise<string | number | boolean | object | null | undefined> {
     this.createDebugLog("executeFunction()");
     const response = await this.child.executeFunction(
       chiliPath,
       functionName,
-      params
+      args
     );
     if (response.isError) {
       throw new Error(response.error)


### PR DESCRIPTION
This fixes bug with AddListener being addListener and RemoveListener being removeListener
This also makes some user improvements, by removing args and removing publisher as an argument.

So instead of doing this:
```js
publisher.customFunction.register("Add", "publisher.alert(args[0] + args[1] + '')")
publisher.customerFunction.execute("Add", [1, 2]);
```
You can do this:
```js
publisher.customFunction.register("Add", "publisher.alert(arguments[0] + arguments[1] + '')")
publisher.customerFunction.execute("Add", 1, 2);
```

This is because we utilize the built in arguments object:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments

Because we use the arguments object, we remove the `publisher` property because it is global and it keeps the arguments[0] not being `publisher`. 