### PR TITLE
Fix test script bug due to missing directory

### DIFF
--- a/test/run_tests.js
+++ b/test/run_tests.js
@@ -33,7 +33,7 @@ async function main() {
 
   const copyPISuccess = await new Promise((res) => {
     exec(
-      "cp ./dist/PublisherInterface.min.js ./test/dist/PublisherInterface.min.js",
+      "mkdir -p ./test/dist && cp ./dist/PublisherInterface.min.js ./test/dist/PublisherInterface.min.js",
       (error, stdout, stderr) => {
         if (error) {
           res([false, error]);


### PR DESCRIPTION
There was a bug due to being unable to copy files into a directly that does not exist. This is fixed by first making the directory with the `mkdir` command and passing the optional `-p` parameter.