### PR TITLE
Major Release Version 1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18
+
+WORKDIR /usr/app
+
+COPY package*.json ./
+
+RUN apt-get update && apt-get -y install libnss3 libatk-bridge2.0-0 libdrm-dev libxkbcommon-dev libgbm-dev libasound-dev libatspi2.0-0 libxshmfence-dev libcups2 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libwayland-client0
+
+RUN npm install
+
+

--- a/README.md
+++ b/README.md
@@ -1,151 +1,187 @@
-# Publisher Interface
-The Publisher Interface was designed to make integrating into CHILI publish Online easy.
+# CHILI Publisher Interface
+The **Publisher Interface** library simplifies integration with CHILI GraFx Publisher by providing a straightforward means to interact with the editorObject via postMessage. This library greatly simplifies the complexity of dealing with the same-origin policy in all browsers including Chromium-based browsers.
 
-As a happy side effect, the setter for `document.domain`, which many integrations rely on, will become immutable at the beginning of January 2023. This means that the Publisher Interface will be the only supported way to communicate with Publisher via an `<iframe>`.
+Notes:
+- The Publisher JavaScript API has maintained stability for years. Thus this library reaching major version 1.x signifies that future updates will primarily address bug fixes, and should be rare. In this case, no updates is a good sign.
+- Some use cases may not be supported by Publisher Interface. Refer to [here]() for unsupported use cases.
+- Previously named Publisher Connector, the project has been renamed to Publisher Interface to avert confusion with future connectors plugin systems. Please update your project if you utilized the old name and library.
+- As of 2023, this is the only officially support way to integrate CHILI GraFx Publisher.
 
-All the magic happens with `PublisherInterface` PublisherInterface is a class object that allows you to interact with the CHILI Editor editorObject via postMessage without the complexity of postMessage.
+<br/>
 
 This project is officially supported by [CHILI publish](https://chili-publish.com).
 
-Notes:
-* The Publisher JavaScript API has been stable for years, and there is no plans to add to it. So this project may not get many updates. That is a good thing, it means there is no bugs.
-* Originally this project was called Publisher Connector. The name was changed to avoid confusion with the future connectors plugin system. Please update your projects if you were using the old naming convention and library.
+## Contents
+- [Installation](#installation)
+- [Getting Started](#getting-started)
+- [Debugging](#debugging)
 
-## Documentation
-You can find complete documentation on the [wiki](https://github.com/chili-publish/publisher-interface/wiki)
-* [Installation](#installation) - Easy npm install.
-* [Getting Started](#getting-started) - A very quick tutorial to get you started.
-* [Debugging](#debugging) - Things gone wrong, check this out.
-* [Integrating Publisher](https://github.com/chili-publish/publisher-interface/wiki/Integrating-Publisher) - A much longer tutorial for those starting a new project with Publisher.
-* [Why I Cannot Use editorObject](https://github.com/chili-publish/publisher-interface/wiki/Why-I-Cannot-Use-editorObject) - A description of why `editorObject` can no longer be used when communicating with an `<iframe>`.
-* [Differences With editorObject](https://github.com/chili-publish/publisher-interface/wiki/Differences-With-editorObject) - All the differences between `PublisherInterface` and `editorObject`.
-* [Moving to Publisher Interface](https://github.com/chili-publish/publisher-interface/wiki/Moving-to-Publisher-Interface) - A guide for those who already have a project with Publisher and are now converting their current integration from `editorObject` to Publisher Interface.
-* [Big List of JavaScript Use Cases](https://github.com/chili-publish/publisher-interface/wiki/Big-List-of-JavaScript-Use-Cases) - A very long list of JavaScript use cases. [WIP]
-* [API Documentation](https://github.com/chili-publish/publisher-interface/wiki/API-Docs) - auto-generated documentation of the `PublisherInterface` class and associated types. Even though it is auto-generated, the comments therein were written with insight.
+<br/>
+
+📘 **Full documentation** is available on the [wiki](https://github.com/chili-publish/publisher-interface/wiki).
 
 ## Installation
-You can install PublisherInterface via npm
+Install Publisher Interface using npm, yarn, bun, or directly in the browser via unpkg.
 
-```
-npm i @chili-publish/publisher-interface
-```
-
-<br/>
-
-or through yarn
-```
-yarn add @chili-publish/publisher-interface
-```
-
-<br/>
-
-You can also use it directly in the browser via unpkg.
 ```javascript
+// npm
+npm i @chili-publish/publisher-interface
+
+// yarn
+yarn add @chili-publish/publisher-interface
+
+// bun
+bun install @chili-publish/publisher-interface
+
+// browser
 import {PublisherInterface} from "https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js";
 ```
 
 ## Dependencies
 The Publisher Interface has 1 dependency which is the [Penpal](https://github.com/Aaronius/penpal) library.
 
-All other dependencies are only for the developer tools such as auto generating docs, testing, and packaging.
+All other dependencies are only for the developer tools such as auto generating docs, testing, and packaging. Developer dependencies will not always be up-to-date, and that is okay because our focus is to keep to keep the package up-to-date , and the developer tools only when releasing a new version.
 
 This means that their is very little security concerns, and the limitations are the same as those found in [Penpal](https://github.com/Aaronius/penpal)
 
 ### Browser Support
 
-Publisher Interface runs successfully on the most recent versions of Chrome, Firefox, Safari, and Edge. Internet Explorer is
-not supported.
-
-## Getting Started
-The easiest way to get started is to pull the package from unpkg.
-
-```javascript
-import {PublisherInterface} from "https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js";
-```
+Publisher Interface runs successfully on CHILI GraFx and any version greater on or above 6.5.5. It is also built to run on the most recent versions of Chrome, Firefox, Safari, and Edge. Internet Explorer is not supported.
 
 <br/>
 
-If you downloaded via NPM you can import it with
+# Getting Started
+Begin by pulling the package from unpkg, or import it if installed via NPM, yarn, or bun.
+
 ```javascript
+//unpkg
+import {PublisherInterface} from "https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js";
+
+// npm, yarn, bun
 import {PublisherInterface} from "@chili-publish/publisher-interface";
 ```
 
 <br/>
 
-Then in your JavaScript code, get the iframe which is loading the Publisher editor, and pass that iframe element into the `build()` function of `PublisherInterface`.
+Subsequently, within your JavaScript code:
+- Retrieve the containing element
+- Invoke the buildOnElement method
 
 ```javascript
-const iframe = document.getElementById("editor-iframe");
-const publisher = PublisherInterface.build(iframe).then(
-    PublisherInterface => PublisherInterface.alert("Hi!")
+const editorDiv = document.getElementById("editor-div");
+const publisher = PublisherInterface.buildOnElement(editorDiv, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0").then(
+    publisher => publisher.alert("Hi!")
 );
 ```
 
-🚨 **Important** - make sure that you call `build()` before the iframe `onload` event is fired. In practice this means that you should never call `build()` when that event is fired.
+<br/>
+
+The code above will create an iframe on the element with `id` "editor-div" using the URL passed in the function as the `src`.
+
+For iframe styling, use `publisher.iframe`.
+
+```javascript
+const editorDiv = document.getElementById("editor-div");
+const publisher = PublisherInterface.buildOnElement(editorDiv, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0").then(
+    publisher => {
+        publisher.iframe.classList.add("coolIFrameStyleInCSS");
+    }
+);
+```
+
+<br/>
+<br/>
+
+We can also use the [async and await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#async_and_await) syntax. Here is the above example using async/await:
+
+```javascript
+const editorDiv = document.getElementById("editor-div");
+const publisher = await PublisherInterface.buildOnElement(editorDiv, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0");
+publisher.iframe.classList.add("coolIFrameStyleInCSS");
+```
 
 <br/>
 
-In simple use cases, the below example will work well.
+Here is a complete example:
+```html
+<body>
+    <div id="editor-div"></div>
+    <iframe id="editor-iframe" style="width:1200px; height:800px"
+        src="https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0"></iframe>
+    <script type="module">
+        import {PublisherInterface} from 'https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js';
+    
+        const element = document.getElementById("editor-div");
+    
+        (async () => {
+            const publisher = await PublisherInterface.buildOnElement(element, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0");
+            
+            publisher.iframe.classList.add("coolIFrameStyleInCSS");
+            
+            const documentName = await publisher.getObject("document.name");
+            
+            console.log(documentName);
+        })();
+    </script>
+</body>
+```
+<br/>
+
+## Your Own iframe
+In versions before 1.0, you would need to use your own iframe when building the `PublisherInterface` class.
+
+To utilize your iframe, employ the buildWithIframe() method.
+
 ```html
 <body>
     <iframe id="editor-iframe" style="width:1200px; height:800px"
-        src="https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G07gMFMq07X+SG2o8KlW8oAeZGqoB1a0YkbeZU1wJK15aIhANgZmhg+13NQlxpBEq7Q=="></iframe>
+        src="https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0"></iframe>
     <script type="module">
         import {PublisherInterface} from 'https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js';
     
         const iframe = document.getElementById("editor-iframe");
     
         (async () => {
-            const publisher = await PublisherInterface.build(iframe);
+            const publisher = await PublisherInterface.buildWithIframe(iframe);
             const documentName = await publisher.getObject("document.name");
             console.log(documentName);
         })();
     </script>
 </body>
+
 ```
 
 <br/>
-When dealing with larger applications, it's important to ensure that the `iframe` and the `PublisherInterface` build method are called in the same JavaScript event loop. To do this, follow these steps:
 
-1. Create the `iframe` element and set its `src` attribute.
-2. Pass the `iframe` element to the `build` method of `PublisherInterface` and capture the promise returned from the method.
-3. Append the `iframe` element to the DOM.
-4. Await the promise captured in step 2 and assign it to a variable that can be used throughout your application.
+🚨 **Important** - `buildWithIframe()` will not resolve if the iframe loads before build() is called. Prefer using `buildOnElement()`.
 
-Example Code:
+<br/>
 
-```html
-<body>
-  <script type="module">
-    import {PublisherInterface} from 'https://unpkg.com/@chili-publish/publisher-interface@latest/dist/PublisherInterface.min.js';
-
-    document.addEventListener("DOMContentLoaded", async () => {
-      (async () => {
-        const iframe = document.createElement("iframe");
-        iframe.src = "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G07gMFMq07X+SG2o8KlW8oAeZGqoB1a0YkbeZU1wJK15aIhANgZmhg+13NQlxpBEq7Q==";
-        const publisherPromise = PublisherInterface.build(iframe);
-        document.body.appendChild(iframe);
-        const publisher = await publisherPromise;
-        const documentName = await publisher.getObject("document.name");
-        console.log(documentName);
-      })();
-    });
-  </script>
-</body>
-```
 ## Debugging
-To enable debugging for the underlying library, pass {penpalDebug: true} as the buildOptions in your build function.
+Activate debugging by passing `{debug: true}` as the commonBuildOptions in your build function.
 
 ```javascript
-PublisherInterface.build(iframe, {penpalDebug: true});
+// If you are letting the iframe be built on an element
+PublisherInterface.buildOnElement(element, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0", {debug: true})
+
+// If you are using your own iframe
+PublisherInterface.buildWithIframe(iframe, {debug: true});
 ```
 
-This will display messages in the console from Penpal about the communication between the iframe and the main page.
+This will display messages in the console about the communication between the iframe and the main page.
 
-If there's a possibility of a failure to connect, you can set a timeout. If the connection is not established before the timeout, an exception will be thrown. In the example below, the build method will throw a timeout after 10 seconds if no connection is established.
+<br/>
+
+To handle potential connection failures, define a timeout as demonstrated below.
 ```javascript
-PublisherInterface.build(iframe, {penpalDebug: true, timeout: 10000});
+// If you are letting the iframe be built on an element
+PublisherInterface.buildOnElement(element, "https://example.chili-publish.online/example/editor_html.aspx?doc=3d178228-a9b9-49d0-90d9-c1c8f8b67f05&apiKey=Sczs1ruhiZcaFiqg0G0", {debug: true, timeout: 10000})
+
+// If you are using your own iframe
+PublisherInterface.buildWithIframe(iframe, {debug: true, timeout: 10000});
 ```
+
+If the connection is not established before the timeout, an exception will be thrown. In the example below, the build method will throw a timeout after 10 seconds if no connection is established.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Notes:
 - The Publisher JavaScript API has maintained stability for years. Thus this library reaching major version 1.x signifies that future updates will primarily address bug fixes, and should be rare. In this case, no updates is a good sign.
 - Some use cases may not be supported by Publisher Interface. Refer to [here]() for unsupported use cases.
 - Previously named Publisher Connector, the project has been renamed to Publisher Interface to avert confusion with future connectors plugin systems. Please update your project if you utilized the old name and library.
-- As of 2023, this is the only officially support way to integrate CHILI GraFx Publisher.
+- As of 2023, this is the only officially supported way to integrate CHILI GraFx Publisher.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Publisher Interface has 1 dependency which is the [Penpal](https://github.co
 
 All other dependencies are only for the developer tools such as auto generating docs, testing, and packaging. Developer dependencies will not always be up-to-date, and that is okay because our focus is to keep to keep the package up-to-date , and the developer tools only when releasing a new version.
 
-This means that their is very little security concerns, and the limitations are the same as those found in [Penpal](https://github.com/Aaronius/penpal)
+This means that there are very little security concerns, and the limitations are the same as those found in [Penpal](https://github.com/Aaronius/penpal)
 
 ### Browser Support
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/usr/app
+      - /usr/app/node_modules
+      - /usr/app/test/dist
+    command: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chili-publish/publisher-interface",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chili-publish/publisher-interface",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "penpal": "^6.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001430",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
-      "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
+      "version": "1.0.30001532",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
+      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
       "dev": true,
       "funding": [
         {
@@ -2088,6 +2088,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -5690,9 +5694,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001430",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001430.tgz",
-      "integrity": "sha512-IB1BXTZKPDVPM7cnV4iaKaHxckvdr/3xtctB3f7Hmenx3qYBhGtTZ//7EllK66aKXW98Lx0+7Yr0kxBtIt3tzg==",
+      "version": "1.0.30001532",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
+      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chili-publish/publisher-interface",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "author": "chili-publish",
   "description": "PublisherInterface is a class object that allows you to interact with the CHILI Publisher editorObject via postMessage without the complexity of postMessage.",
   "repository": {

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -182,11 +182,11 @@ export type CustomFunctionsInterface = {
 }
 
 
-const createCustomFunctionsInterface = function(chiliWrapper:AsyncMethodReturns<ChiliWrapper>, createDebugLog:(log:string)=>void):CustomFunctionsInterface {
+const createCustomFunctionsInterface = function(chiliWrapper:AsyncMethodReturns<ChiliWrapper>, createDebugLog:(p:{functionName:string})=>void):CustomFunctionsInterface {
   return {
 
     register: async function(name:string, body:string): Promise<void> {
-      createDebugLog("registerFunction()");
+      createDebugLog({functionName:"registerFunction()"});
       const response = await chiliWrapper.registerFunction(name, body);
       if (response.isError) {
         throw new Error(response.error)
@@ -194,7 +194,7 @@ const createCustomFunctionsInterface = function(chiliWrapper:AsyncMethodReturns<
     },
   
     registerOnEvent: async function(eventName:string, body:string): Promise<void> {
-      createDebugLog("registerFunction()");
+      createDebugLog({functionName:"registerFunction()"});
       const response = await chiliWrapper.registerFunctionOnEvent(eventName, body);
       if (response.isError) {
         throw new Error(response.error)
@@ -202,7 +202,7 @@ const createCustomFunctionsInterface = function(chiliWrapper:AsyncMethodReturns<
     },
   
     execute: async function(name: string, ...args:any): Promise<any> {
-      createDebugLog("executeRegisteredFunction()");
+      createDebugLog({functionName:"executeRegisteredFunction()"});
       const response = await chiliWrapper.executeRegisteredFunction(name, args);
       if (response.isError) {
         throw new Error(response.error);
@@ -248,6 +248,8 @@ export class PublisherInterface {
   static async build(options:buildOptions) {
     const publisherInterface = new PublisherInterface();
     publisherInterface.creationTime = new Date().toLocaleString();
+    publisherInterface.debug = options.debug ?? false;
+    publisherInterface.createDebugLog({functionName:"build()", customMessage:"Calling build() with options: " + JSON.stringify(options)})
 
     const iframe = options.iframe ?? document.createElement("iframe");
     publisherInterface.iframe = iframe;
@@ -273,7 +275,6 @@ export class PublisherInterface {
 
     publisherInterface.child = await connectionPromise.promise;
     publisherInterface.customFunction = createCustomFunctionsInterface(publisherInterface.child, publisherInterface.createDebugLog.bind(publisherInterface));
-    publisherInterface.debug = options.debug ?? false;
 
     const events = options.events;
 
@@ -298,12 +299,17 @@ export class PublisherInterface {
   }
 
   /**
-   * Logs a function call creation if penpalDebug is enabled
+   * Logs a function call creation if debug is enabled
    * @param functionName The name of the function being executed
    */
-  private createDebugLog(functionName: string) {
+  private createDebugLog({functionName, customMessage}:{functionName: string, customMessage?:string}) {
     if (this.debug) {
-      console.log(`[PublisherInterface - ${this.creationTime}]`, `Creating ${functionName} call request`);
+      if (customMessage != null) {
+        console.log(`[PublisherInterface - ${this.creationTime}]`, `${functionName} : ${customMessage}`);
+      }
+      else {
+        console.log(`[PublisherInterface - ${this.creationTime}]`, `Creating ${functionName} call request`);
+      }
     }
   }
 
@@ -349,7 +355,7 @@ export class PublisherInterface {
    * @param title - The title/header of the modal.
    */
   public async alert(message: string, title: string): Promise<void> {
-    this.createDebugLog("alert()");
+    this.createDebugLog({functionName:"alert()"});
     const response = await this.child.alert(message, title);
     if (response.isError) {
       throw new Error(response.error)
@@ -362,7 +368,7 @@ export class PublisherInterface {
    * @returns Returns boolean to signify if the document has been changed since previous save.
    */
   public async getDirtyState(): Promise<boolean> {
-    this.createDebugLog("getDirtyState()");
+    this.createDebugLog({functionName:"getDirtyState()"});
     const response = await this.child.getDirtyState();
     if (response.isError) {
       throw new Error(response.error)
@@ -375,7 +381,7 @@ export class PublisherInterface {
    * If the current selected page has the beginning index 0 then nothing happens.
    */
   public async nextPage(): Promise<void> {
-    this.createDebugLog("nextPage()");
+    this.createDebugLog({functionName:"nextPage()"});
     const response = await this.child.nextPage();
     if (response.isError) {
       throw new Error(response.error)
@@ -387,7 +393,7 @@ export class PublisherInterface {
    * If the current selected page has the last index then nothing happens.
    */
   public async previousPage(): Promise<void> {
-    this.createDebugLog("previousPage()");
+    this.createDebugLog({functionName:"previousPage()"});
     const response = await this.child.previousPage();
     if (response.isError) {
       throw new Error(response.error)
@@ -400,7 +406,7 @@ export class PublisherInterface {
    * @param page - Common language page number (page index + 1) to select.
    */
   public async setSelectedPage(page: number): Promise<void> {
-    this.createDebugLog("setSelectedPage()");
+    this.createDebugLog({functionName:"setSelectedPage()"});
     const response = await this.child.setSelectedPage(page);
     if (response.isError) {
       throw new Error(response.error)
@@ -414,7 +420,7 @@ export class PublisherInterface {
    * @returns Page index + 1 of the selected page.
    */
   public async getSelectedPage(): Promise<number> {
-    this.createDebugLog("getSelectedPage()");
+    this.createDebugLog({functionName:"getSelectedPage()"});
     const response = await this.child.getSelectedPage();
     if (response.isError) {
       throw new Error(response.error)
@@ -428,7 +434,7 @@ export class PublisherInterface {
    * @returns Name of the page.
    */
   public async getSelectedPageName(): Promise<string> {
-    this.createDebugLog("getSelectedPageName()");
+    this.createDebugLog({functionName:"getSelectedPageName()"});
     const response = await this.child.getSelectedPageName();
     if (response.isError) {
       throw new Error(response.error)
@@ -442,7 +448,7 @@ export class PublisherInterface {
    * @returns The total number of pages.
    */
   public async getNumPages(): Promise<number> {
-    this.createDebugLog("getNumPages()");
+    this.createDebugLog({functionName:"getNumPages()"});
     const response = await this.child.getNumPages();
     if (response.isError) {
       throw new Error(response.error)
@@ -456,7 +462,7 @@ export class PublisherInterface {
    * @param eventName - A case-sensitive string representing the editor event type to stop listening to.
    */
   public async removeListener(eventName: string): Promise<void> {
-    this.createDebugLog("removeListener()");
+    this.createDebugLog({functionName:"removeListener()"});
     this.chiliEventListenerCallbacks.delete(eventName);
     const response = await this.child.removeListener(eventName);
     if (response.isError) {
@@ -480,7 +486,7 @@ export class PublisherInterface {
     callbackFunction?: (target: string) => void
   ): Promise<void> {
 
-    this.createDebugLog("addListener()");
+    this.createDebugLog({functionName:"addListener()"});
     this.chiliEventListenerCallbacks.set(eventName, callbackFunction == null ? (targetID) => {
       if (window.OnEditorEvent != null) window.OnEditorEvent(eventName, targetID)
     } : callbackFunction)
@@ -500,7 +506,7 @@ export class PublisherInterface {
   public async getObject(
     chiliPath: string
   ): Promise<string | number | boolean | object | null | undefined> {
-    this.createDebugLog("getObject()");
+    this.createDebugLog({functionName:"getObject()"});
     const response = await this.child.getObject(chiliPath);
     if (response.isError) {
       throw new Error(response.error)
@@ -525,7 +531,7 @@ export class PublisherInterface {
     property: string,
     value: string | number | boolean | null
   ): Promise<void> {
-    this.createDebugLog("setProperty()");
+    this.createDebugLog({functionName:"setProperty()"});
     const response = await this.child.setProperty(chiliPath, property, value);
     if (response.isError) {
       throw new Error(response.error)
@@ -550,7 +556,7 @@ export class PublisherInterface {
     functionName: string,
     ...args: (string | number | boolean | null | undefined)[]
   ): Promise<string | number | boolean | object | null | undefined> {
-    this.createDebugLog("executeFunction()");
+    this.createDebugLog({functionName:"executeFunction()"});
     const response = await this.child.executeFunction(
       chiliPath,
       functionName,
@@ -593,7 +599,7 @@ export class PublisherInterface {
     viewMode: "preview" | "edit" | "technical",
     transparentBackground: boolean
   ): Promise<string> {
-    this.createDebugLog("getPageSnapshot()");
+    this.createDebugLog({functionName:"getPageSnapshot()"});
     const response = await this.child.getPageSnapshot(
       pageIndex,
       size,
@@ -621,7 +627,7 @@ export class PublisherInterface {
     size: string | { width: number; height: number } | number,
     transparentBackground: boolean
   ): Promise<string> {
-    this.createDebugLog("getFrameSnapshot()");
+    this.createDebugLog({functionName:"getFrameSnapshot()"});
     const response = await this.child.getFrameSnapshot(
       idOrTag,
       size,
@@ -642,7 +648,7 @@ export class PublisherInterface {
   public async getFrameSubjectArea(
     idOrTag: string
   ): Promise<{ height: string; width: string; x: string; y: string }> {
-    this.createDebugLog("getFrameSubjectArea()");
+    this.createDebugLog({functionName:"getFrameSubjectArea()"});
     const response = await this.child.getFrameSubjectArea(idOrTag);
     if (response.isError) {
       throw new Error(response.error)
@@ -666,7 +672,7 @@ export class PublisherInterface {
     width: number,
     height: number
   ): Promise<void> {
-    this.createDebugLog("setFrameSubjectArea()");
+    this.createDebugLog({functionName:"setFrameSubjectArea()"});
     const response = await this.child.setFrameSubjectArea(
       idOrTag,
       x,
@@ -685,7 +691,7 @@ export class PublisherInterface {
    * @param idOrTag - The string id or tag of the frame to clear the subject area.
    */
   public async clearFrameSubjectArea(idOrTag: string): Promise<void> {
-    this.createDebugLog("clearFrameSubjectArea()");
+    this.createDebugLog({functionName:"clearFrameSubjectArea()"});
     const response = await this.child.clearFrameSubjectArea(idOrTag);
     if (response.isError) {
       throw new Error(response.error)
@@ -706,7 +712,7 @@ export class PublisherInterface {
     poiX: string;
     poiY: string;
   }> {
-    this.createDebugLog("getAssetSubjectInfo()");
+    this.createDebugLog({functionName:"getAssetSubjectInfo()"});
     const response = await this.child.getAssetSubjectInfo(frameIdOrTag);
     if (response.isError) {
       throw new Error(response.error)
@@ -734,7 +740,7 @@ export class PublisherInterface {
     poiX: number,
     poiY: number
   ): Promise<void> {
-    this.createDebugLog("setAssetSubjectInfo()");
+    this.createDebugLog({functionName:"setAssetSubjectInfo()"});
     const response = await this.child.setAssetSubjectInfo(
       frameIdOrTag,
       x,
@@ -755,7 +761,7 @@ export class PublisherInterface {
    * @param frameIdOrTag - The string id or tag of the frame to clear the asset subject area.
    */
   public async clearAssetSubjectInfo(frameIdOrTag: string): Promise<void> {
-    this.createDebugLog("clearAssetSubjectInfo()");
+    this.createDebugLog({functionName:"clearAssetSubjectInfo()"});
     const response = await this.child.clearAssetSubjectInfo(frameIdOrTag);
     if (response.isError) {
       throw new Error(response.error)
@@ -772,7 +778,7 @@ export class PublisherInterface {
     variableName: string,
     isLocked: boolean
   ): Promise<void> {
-    this.createDebugLog("setVariableIsLocked()");
+    this.createDebugLog({functionName:"setVariableIsLocked()"});
     const response = await this.child.setVariableIsLocked(
       variableName,
       isLocked

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -247,6 +247,7 @@ export class PublisherInterface {
    */
   static async build(options:buildOptions) {
     const publisherInterface = new PublisherInterface();
+    publisherInterface.creationTime = new Date().toLocaleString();
 
     const iframe = options.iframe ?? document.createElement("iframe");
     publisherInterface.iframe = iframe;
@@ -254,8 +255,8 @@ export class PublisherInterface {
     if (options.editorURL != null) {
       iframe.src = options.editorURL;
     }
-
-    publisherInterface.child = await connectToChild<ChiliWrapper>({
+    
+    const connectionPromise = connectToChild<ChiliWrapper>({
       // The iframe to which a connection should be made
       iframe,
       // Methods the parent is exposing to the child
@@ -264,17 +265,15 @@ export class PublisherInterface {
       },
       timeout: options.timeout,
       debug: options.debug
-    }).promise;
+    })
 
-    if (options.iframe == null) {
+    if (options.createIFrameOnElement != null) {
       options.createIFrameOnElement.appendChild(iframe);
     }
 
+    publisherInterface.child = await connectionPromise.promise;
     publisherInterface.customFunction = createCustomFunctionsInterface(publisherInterface.child, publisherInterface.createDebugLog.bind(publisherInterface));
     publisherInterface.debug = options.debug ?? false;
-    
-    publisherInterface.creationTime = new Date().toLocaleString();
-    publisherInterface.createDebugLog("build()");
 
     const events = options.events;
 

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -117,7 +117,7 @@ interface ChiliWrapper {
   ): Result<undefined>;
 }
 
-export type commonBuildOptions = {
+export type CommonBuildOptions = {
     /**
      * If not null, the number of milliseconds to wait for a connection to iframe before throwing an exception.
      */
@@ -133,7 +133,7 @@ export type commonBuildOptions = {
   }
 
 
-export type allBuildOptions = ({
+export type AllBuildOptions = ({
   /** 
    * iframe element to the PublisherInterface will try to connect with
   */
@@ -155,7 +155,7 @@ export type allBuildOptions = ({
    */
   parentElement: HTMLElement,
 })
- & commonBuildOptions
+ & CommonBuildOptions
 
 export type CustomFunctionsInterface = {
     /**
@@ -240,11 +240,11 @@ export class PublisherInterface {
   private constructor() {
   }
 
-  static async buildWithIframe(targetIframe:HTMLIFrameElement, options:commonBuildOptions) {
+  static async buildWithIframe(targetIframe:HTMLIFrameElement, options:CommonBuildOptions) {
     return PublisherInterface.build({targetIframe, ...options})
   }
 
-  static async buildOnElement(parentElement:HTMLElement, editorURL:string, options:commonBuildOptions) {
+  static async buildOnElement(parentElement:HTMLElement, editorURL:string, options:CommonBuildOptions) {
     return PublisherInterface.build({parentElement, editorURL, ...options})
   }
 
@@ -255,7 +255,7 @@ export class PublisherInterface {
    * @param options
    * @returns {PublisherInterface}
    */
-  static async build(options:allBuildOptions) {
+  static async build(options:AllBuildOptions) {
     
     // Supporting code that is expecting pre 1.0 behavior
     if (arguments[0].tagName == "IFRAME"){

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -259,10 +259,13 @@ export class PublisherInterface {
     
     // Supporting code that is expecting pre 1.0 behavior
     if (arguments[0].tagName == "IFRAME"){
+
+      const originalOptions = arguments[1] ?? {};
+
       options = {
-        ...arguments[1],
+        ...originalOptions,
         targetIframe: arguments[0],
-        debug: arguments[1]["penpalDebug"]
+        debug: options.debug ?? originalOptions["penpalDebug"]
       }
     }
     

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -256,6 +256,16 @@ export class PublisherInterface {
    * @returns {PublisherInterface}
    */
   static async build(options:allBuildOptions) {
+    
+    // Supporting code that is expecting pre 1.0 behavior
+    if (arguments[0].tagName == "IFRAME"){
+      options = {
+        ...arguments[1],
+        targetIframe: arguments[0],
+        debug: arguments[1]["penpalDebug"]
+      }
+    }
+    
     const publisherInterface = new PublisherInterface();
     publisherInterface.creationTime = new Date().toLocaleString();
     publisherInterface.debug = options.debug ?? false;

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -137,7 +137,7 @@ export type allBuildOptions = ({
   /** 
    * iframe element to the PublisherInterface will try to connect with
   */
-  targetIFrame:HTMLIFrameElement,
+  targetIframe:HTMLIFrameElement,
   /**
    * The url that will be set on the iframe - this needs to be a valid URL with a valid API key
    */
@@ -145,7 +145,7 @@ export type allBuildOptions = ({
   parentElement?: undefined
 
 } | {
-  targetIFrame?: undefined
+  targetIframe?: undefined
   /**
    * The url that will be set on the iframe - this needs to be a valid URL with a valid API key
    */
@@ -240,8 +240,8 @@ export class PublisherInterface {
   private constructor() {
   }
 
-  static async buildWithIFrame(targetIFrame:HTMLIFrameElement, options:commonBuildOptions) {
-    return PublisherInterface.build({targetIFrame, ...options})
+  static async buildWithIframe(targetIframe:HTMLIFrameElement, options:commonBuildOptions) {
+    return PublisherInterface.build({targetIframe, ...options})
   }
 
   static async buildOnElement(parentElement:HTMLElement, editorURL:string, options:commonBuildOptions) {
@@ -261,7 +261,7 @@ export class PublisherInterface {
     publisherInterface.debug = options.debug ?? false;
     publisherInterface.createDebugLog({functionName:"build()", customMessage:"Calling build() with options: " + JSON.stringify(options)})
 
-    const iframe = options.targetIFrame ?? document.createElement("iframe");
+    const iframe = options.targetIframe ?? document.createElement("iframe");
     publisherInterface.iframe = iframe;
 
     if (options.editorURL != null) {

--- a/test/PublisherInterface.spec.ts
+++ b/test/PublisherInterface.spec.ts
@@ -99,7 +99,7 @@ const testsPublisherInterface = {
 }
 
 for (const name of Object.keys(testsPublisherInterface)) {
-    test("Test " + name, async ({ page }) => {
+  test("Test " + name + " [pass iframe]", async ({ page }) => {
       await page.goto("http://localhost:3001");
       const result = await page.evaluate(
         (test) => window.runTest(test),
@@ -107,4 +107,12 @@ for (const name of Object.keys(testsPublisherInterface)) {
       );
       expect(result).toBe(true);
   });
+  test("Test " + name + " [build iframe]", async ({ page }) => {
+    await page.goto("http://localhost:3001");
+    const result = await page.evaluate(
+      (test) => window.runTest(test),
+      {name, send:testsPublisherInterface[name].send, response:testsPublisherInterface[name].response, file:"publisherInterface", passIframe:false}
+    );
+    expect(result).toBe(true);
+});
 }

--- a/test/PublisherInterface.spec.ts
+++ b/test/PublisherInterface.spec.ts
@@ -99,11 +99,19 @@ const testsPublisherInterface = {
 }
 
 for (const name of Object.keys(testsPublisherInterface)) {
-  test("Test " + name + " [pass iframe]", async ({ page }) => {
+  test("Test " + name + " [pass iframe preV1]", async ({ page }) => {
       await page.goto("http://localhost:3001");
       const result = await page.evaluate(
         (test) => window.runTest(test),
-        {name, send:testsPublisherInterface[name].send, response:testsPublisherInterface[name].response, file:"publisherInterface"}
+        {name, send:testsPublisherInterface[name].send, response:testsPublisherInterface[name].response, file:"publisherInterface", passIframe:"preV1"}
+      );
+      expect(result).toBe(true);
+  });
+  test("Test " + name + " [pass iframe postV1]", async ({ page }) => {
+      await page.goto("http://localhost:3001");
+      const result = await page.evaluate(
+        (test) => window.runTest(test),
+        {name, send:testsPublisherInterface[name].send, response:testsPublisherInterface[name].response, file:"publisherInterface", passIframe:"postV1"}
       );
       expect(result).toBe(true);
   });

--- a/test/client/publisherInterface.js
+++ b/test/client/publisherInterface.js
@@ -1,13 +1,10 @@
 import {PublisherInterface} from "../dist/PublisherInterface.min.js";
 import {deepEqual} from "./deepEqual.js"
 
-export default async function ({name, send, response}) {
+export default async function ({name, send, response, passIframe = true}) {
   
-  const iframe = document.createElement("iframe");
-  iframe.src = `/server/publisherInterface.html`;
-
-  const publisher = await createInterface(iframe)
-  await createTestFor(name, response, iframe);
+  const publisher = await createInterface(passIframe)
+  await createTestFor(name, response, publisher.iframe);
 
   const [receivedOnIframe, responseFromIframe] = await Promise.all([
     new Promise(res => {
@@ -41,10 +38,19 @@ async function createTestFor(name, response, iframe) {
   });
 }
 
-async function createInterface(iframe, options = {}) {
-  const publisherPromise = PublisherInterface.build(iframe, {timeout:5000, ...options});
-  document.body.appendChild(iframe);
-  return publisherPromise;
+async function createInterface(passIframe) {
+
+  if (passIframe){
+    const iframe = document.createElement("iframe");
+    iframe.src = `/server/publisherInterface.html`;
+
+    const publisherPromise = PublisherInterface.build({iframe:iframe, timeout:5000});
+    document.body.appendChild(iframe);
+    return publisherPromise;
+  }
+  else {
+    return PublisherInterface.build({createIFrameOnElement:document.body, editorURL: `/server/publisherInterface.html`, timeout:5000});
+  }
 }
 
 function lowerFirstLetter(str) {

--- a/test/client/publisherInterface.js
+++ b/test/client/publisherInterface.js
@@ -1,7 +1,7 @@
 import {PublisherInterface} from "../dist/PublisherInterface.min.js";
 import {deepEqual} from "./deepEqual.js"
 
-export default async function ({name, send, response, passIframe = true}) {
+export default async function ({name, send, response, passIframe}) {
   
   const publisher = await createInterface(passIframe)
   await createTestFor(name, response, publisher.iframe);
@@ -40,16 +40,25 @@ async function createTestFor(name, response, iframe) {
 
 async function createInterface(passIframe) {
 
-  if (passIframe){
-    const iframe = document.createElement("iframe");
-    iframe.src = `/server/publisherInterface.html`;
+  switch (passIframe) {
+    case "preV1": {
+      const iframe = document.createElement("iframe");
+      iframe.src = `/server/publisherInterface.html`;
 
-    const publisherPromise = PublisherInterface.build({iframe:iframe, timeout:5000});
-    document.body.appendChild(iframe);
-    return publisherPromise;
-  }
-  else {
-    return PublisherInterface.build({createIFrameOnElement:document.body, editorURL: `/server/publisherInterface.html`, timeout:5000});
+      const publisherPromise = PublisherInterface.build(iframe, {timeout:5000});
+      document.body.appendChild(iframe);
+      return publisherPromise;
+    }
+    case "postV1": {
+      const iframe = document.createElement("iframe");
+      iframe.src = `/server/publisherInterface.html`;
+
+      const publisherPromise = PublisherInterface.buildWithIframe(iframe, {timeout:5000});
+      document.body.appendChild(iframe);
+      return publisherPromise;
+    }
+    default:
+    return PublisherInterface.buildOnElement(document.body, `/server/publisherInterface.html`, {timeout:5000});
   }
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -4,32 +4,6 @@
     <script type="module">
       window.runTest = async (options) => {
 
-        // console.log(options);
-        // return options.result;
-        // const iframe = document.createElement("iframe");
-        // iframe.src = `/server/${file}.html`;
-
-        // const createInterface = async (options = {}) => {
-        //   const publisherPromise = PublisherInterface.build(iframe, {timeout:5000, ...options});
-        //   document.body.appendChild(iframe);
-        //   return publisherPromise;
-        // }
-
-        // const createTestFor = async (testName) => {
-        //   iframe.contentWindow.postMessage({addTest:true, testName}, "*");
-
-        //   return new Promise( res => {
-        //     const createTestListener = (event) => {
-        //       //testReady: true, testName: event.data.testName
-        //       if (event.data.testReady && event.data.testName == testName) {
-        //         res(testName);
-        //       }
-        //     }
-
-        //     window.addEventListener("message", createTestListener)
-        //   });
-        // }
-
         const { default: testFunction } = await import(`/client/${options.file}.js`);
         const result = await testFunction(options);
 


### PR DESCRIPTION
## Version 1.0 Differences
With this PR, we are releasing major version 1.0. There is no 2.0 planned, and after this point this project will go into maintenance.

The only real change with 1.0 is the change of the `build()` method.

Pre-1.0, the `build()` method had a signature like:
```typescript
(a:HTMLIFrameElement, b:buildOptions) => Promise<PublisherInterface>
```

<br/>

Post-1.0, the `build()` method looks like:
```typescript
(a:AllBuildOptions) => Promise<PublisherInterface>
```

The differences here is that the type `AllBuildOptions` has all the configurable options to build the `PublisherInterface` object.

<br/>

Other changes:
- New helper build functions
- Added test cases for the new helper methods
- Added docker file for running tests
- Updated README

<br/>

## Why Change `build()`?
During the lifespan of this project, we have had a number of clients report issues using `build()` where the iframe provided would load before the `build()` method was called.

While this was documented, and eventually a solution was documented, it became clear that we need to steer developers towards a better method (pun intended).

By requiring a config to call `build()`, this requires developers to think about what they are doing.

However, developers being developers, sometimes we are too busy to think about inner workings, and thus `buildOnElement()` method was added to promote the safer pathway forward.

`buildWithIframe()` was also added to allow those who understand the consequences to bring their own iframe to the party.

Or you can use `build()` directly.

<br/>

Consequently, this allows us to extend `build()`, if required, in away that won't break integrations or require internal workarounds.
 