### PR TITLE
Handle Circular Structure JSON Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chili-publish/publisher-interface",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@chili-publish/publisher-interface",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "penpal": "^6.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chili-publish/publisher-interface",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "chili-publish",
   "description": "PublisherInterface is a class object that allows you to interact with the CHILI Publisher editorObject via postMessage without the complexity of postMessage.",
   "repository": {

--- a/src/PublisherInterface.ts
+++ b/src/PublisherInterface.ts
@@ -243,7 +243,6 @@ export class PublisherInterface {
   static async buildWithIframe(targetIframe:HTMLIFrameElement, options:CommonBuildOptions) {
     return PublisherInterface.build({targetIframe, ...options})
   }
-
   static async buildOnElement(parentElement:HTMLElement, editorURL:string, options:CommonBuildOptions) {
     return PublisherInterface.build({parentElement, editorURL, ...options})
   }
@@ -268,11 +267,13 @@ export class PublisherInterface {
         debug: options.debug ?? originalOptions["penpalDebug"]
       }
     }
-    
+   
+    const stringifiedOptions = ((opts:AllBuildOptions) => {try {return JSON.stringify(opts)} catch (e:any) {return e.toString()}})(options);
+
     const publisherInterface = new PublisherInterface();
     publisherInterface.creationTime = new Date().toLocaleString();
     publisherInterface.debug = options.debug ?? false;
-    publisherInterface.createDebugLog({functionName:"build()", customMessage:"Calling build() with options: " + JSON.stringify(options)})
+    publisherInterface.createDebugLog({functionName:"build()", customMessage:"Calling build() with options: " + stringifiedOptions});
 
     const iframe = options.targetIframe ?? document.createElement("iframe");
     publisherInterface.iframe = iframe;


### PR DESCRIPTION
Customer reported the following error when calling `build()`:
```
Calling build() with options: TypeError: Converting circular structure to JSON
```

By default, this error should not occur. However, in JavaScript, one can inadvertently create a circular options object or introduce a circular reference in the iframe DOM element. Although this issue hasn't been reproduced without intentionally introducing circular logic, our library should address and manage it gracefully.